### PR TITLE
Makes a change so that some controls can work outside of a Font Info window

### DIFF
--- a/Lib/defconAppKit/controls/fontInfoView.py
+++ b/Lib/defconAppKit/controls/fontInfoView.py
@@ -31,7 +31,8 @@ class DefconAppKitTextField(NSTextField):
         result = super(DefconAppKitTextField, self).becomeFirstResponder()
         if result:
             view = self.superview()
-            view.scrollControlToVisible_(self)
+            if hasattr(view, "scrollControlToVisible_"):
+                view.scrollControlToVisible_(self)
         return result
 
 
@@ -49,7 +50,8 @@ class DefconAppKitTextView(NSTextView):
         if result:
             scrollView = self.enclosingScrollView()
             view = scrollView.superview()
-            view.scrollControlToVisible_(scrollView)
+            if hasattr(view, "scrollControlToVisible_"):
+                view.scrollControlToVisible_(scrollView)
         return result
 
 
@@ -82,7 +84,8 @@ class DefconAppKitTableView(VanillaTableViewSubclass):
                 if hasattr(view, "scrollControlToVisible_"):
                     break
             if view is not None:
-                view.scrollControlToVisible_(parentView)
+                if hasattr(view, "scrollControlToVisible_"):
+                    view.scrollControlToVisible_(parentView)
         return result
 
 


### PR DESCRIPTION
A small change to allow for some controls to work outside of a Font Info window where a view might not have a `scrollControlToVisible_` attribute.

This code would result in an `AttributeError` but is fixed with this PR

```python
import vanilla
from defconAppKit.controls.fontInfoView import NumberEditText

class NumberEditTextTest:
    
    def __init__(self):
        self.w = vanilla.Window((200, 100))
        self.w.value = NumberEditText((20, 20, -20, 25), "", allowFloat=True, allowNegative=False, minimum=0, callback=self.value2Changed)
        self.w.result = vanilla.TextBox((20, 60, -20, 25), "")
        self.w.open()
    
    def value2Changed(self, sender):
        self.w.result.set(sender.get())

NumberEditTextTest()
```

`AttributeError: 'NSView' object has no attribute 'scrollControlToVisible_'`
