### PR TITLE
Makes the characterToGlyphName function compatible with Python 3

### DIFF
--- a/Lib/defconAppKit/tools/textSplitter.py
+++ b/Lib/defconAppKit/tools/textSplitter.py
@@ -1,13 +1,9 @@
 def characterToGlyphName(c, cmap):
-    try:
-        c = unicode(c)
-        v = ord(c)
-        v = cmap.get(v)
-        if isinstance(v, list):
-            v = v[0]
-        return v
-    except UnicodeDecodeError:
-        return None
+    v = ord(c)
+    v = cmap.get(v)
+    if isinstance(v, list):
+        v = v[0]
+    return v
 
 
 def splitText(text, cmap, fallback=".notdef"):


### PR DESCRIPTION
Makes the characterToGlyphName function compatible with Python 3 (but not 2 but that seems okay) by removing the unicode() function call.

Python 3 trips on the `unicode()` call, and after removing the unicode conversion I don't think the `UnicodeDecodeError` exception is needed.