### PR TITLE
Adds the ability to set stroke color and cutoff sizes for drawing attributes in the glyphLineView

### DIFF
--- a/Lib/defconAppKit/tools/drawing.py
+++ b/Lib/defconAppKit/tools/drawing.py
@@ -365,14 +365,16 @@ def drawGlyphFillAndStroke(glyph, scale, rect,
 # points
 
 def drawGlyphPoints(glyph, scale, rect, drawStartPoint=True, drawOnCurves=True, drawOffCurves=True, drawCoordinates=True, color=None, backgroundColor=None, flipped=False):
+    # get the layer color
     layer = glyph.layer
-    if layer is not None:
-        if layer.color is not None:
-            color = colorToNSColor(layer.color)
-    if color is None:
+    layerColor = None
+    if layer is not None and layer.color is not None:
+        layerColor = colorToNSColor(layer.color)
+    # work out the colors
+    if color is None and layerColor is not None:
+        color = layerColor
+    elif color is None and layerColor is None:
         color = getDefaultColor("glyphPoints")
-    if backgroundColor is None:
-        backgroundColor = getDefaultColor("background")
     # get the outline data
     outlineData = glyph.getRepresentation("defconAppKit.OutlineInformation")
     points = []


### PR DESCRIPTION
Following the how the interface is arranged to set the drawing attributes in the glyphLineView with `setDrawingAttribute_value_layerName_()`, this PR adds the ability to set the point size cutoffs for drawing attributes with `setCutoffDisplayPointSizeAttribute_value_()` instead of using preset hard-coded point sizes.

The PR also adds the ability to set the stroke color, otherwise the color of the stroke and points would always be forced to use the layer color.